### PR TITLE
Fix v7_MGP option

### DIFF
--- a/SNPsplit_genome_preparation
+++ b/SNPsplit_genome_preparation
@@ -1337,7 +1337,7 @@ sub process_commandline{
 				   'dual_hybrid'          => \$dual_hybrid,
 				   'reference_genome=s'   => \$genome_folder,
 				   'genome_build=s'       => \$genome_build,
-				   'v7_VCF'               => \$v7_MGP_file,
+				   'v7_MGP'               => \$v7_MGP_file,
 	);
   
     ### EXIT ON ERROR if there were errors with any of the supplied options


### PR DESCRIPTION
In the help message, the option is `--v7_MPG `. But in the `process_commandline`, it is written as `v7_VCF`.

https://github.com/FelixKrueger/SNPsplit/blob/2ccda31a0ad390a5e0ca38c3f86d57be4936ac41/SNPsplit_genome_preparation#L1584