### PR TITLE
add STAR in PG paired detection

### DIFF
--- a/SNPsplit
+++ b/SNPsplit
@@ -1637,7 +1637,7 @@ sub check_for_bs{
 			}
 			
 			# Paired-end test
-			if ($_ =~ /ID:Bismark/ or $_ =~ /ID:hisat2/ or $_ =~ /ID:bowtie2/){
+			if ($_ =~ /ID:Bismark/ or $_ =~ /ID:hisat2/ or $_ =~ /ID:bowtie2/ or $_ =~ /ID:STAR/){
 				unless ($paired_end){ # unless the user specified --paired we try to extract this information from the @PG line
 
 					if ($_ =~ /\s+-1\s+/ and $_ =~ /\s+-2\s+/){


### PR DESCRIPTION
Hi,

I've hit a case where I have single-end data aligned with STAR. Running with flags:

```
--snp_file SNPgenome/all_CAST_EiJ_SNPs_C57BL_6NJ_reference.based_on_GRCm38.txt
--no_sort
-o RNAsplit
```

gave me the error:

`Unable to detect library type automatically, please specify whether the file is single- or paired-end manually `

It doesn't seem that I can specify single-end (as --paired is a flag). 
Adding the ID:STAR circumvents this error, though I'm not sure if it makes sense to solve this here (not really familiar with perl).

Kind regards,

WardDeb
