### PR TITLE
Stamp 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.9.0 (Release 17 08 2026)
 
 - **Breaking:** all 34 samtools, gzip and gunzip invocations now run without a shell, so paths containing a space or a shell metacharacter work throughout ([#99](https://github.com/FelixKrueger/SNPsplit/issues/99))
 

--- a/SNPsplit
+++ b/SNPsplit
@@ -23,7 +23,7 @@ use Cwd;
 ## along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 ## Reading in a BAM or SAM file
-my $pipeline_version = '0.8.0';
+my $pipeline_version = '0.9.0';
 my $parent_dir = getcwd;
 my $full_commandline = join (" ","SNPsplit",@ARGV);
 # warn "Full commandline: $full_commandline\n"; sleep(5);

--- a/SNPsplit_genome_preparation
+++ b/SNPsplit_genome_preparation
@@ -34,7 +34,7 @@ use Cwd;
 # https://ftp.ebi.ac.uk/pub/databases/mousegenomes/REL-2112-v8-SNPs_Indels/  "mgp_REL2021_snps.vcf.gz"
 
 ## Reading in a BAM or SAM file
-my $pipeline_version = '0.8.0';
+my $pipeline_version = '0.9.0';
 my $parent_dir = getcwd();
 my ($vcf_file,$strain,$strain2,$strain_index,$strain2_index,$genome_folder,$skip_filtering,$nmasking,$full_sequence,$dual_hybrid,$genome_build,$v7) = process_commandline ();
 

--- a/tag2sort
+++ b/tag2sort
@@ -26,7 +26,7 @@ use lib "$Bin/../lib";
 my %counting;
 my %fhs;
 
-my $SNPsplit_version = '0.8.0';
+my $SNPsplit_version = '0.9.0';
 my %yaml;
 my $yaml_count = 0;
 


### PR DESCRIPTION
Version strings and the changelog heading. No expected output changes: the version is masked in the YAML and absent from every report.
