### PR TITLE
Refuse to compare two revisions that are the same commit

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -356,9 +356,22 @@ BAM headers are compared with `@PG` removed, because `@PG` records the argv and 
 `samtools view -o` rather than a shell redirect. `version`, `date_run` and `command` are filtered from
 the reports for the same reason the YAML masks them.
 
-Exit status is 0 when nothing that matters changed, 1 when something did, and **2 when either run
-failed** — that last case exists because a run that produces nothing would otherwise pass the comparison
-with no files to compare, which is the vacuous pass the rest of this suite is built to avoid.
+Each side prints what its revision resolved to and what it calls itself:
+
+```
+[0.6.0]         0.6.0         is 6e49c58, and reports version 0.6.0
+[origin_master] origin/master is 499292f, and reports version 0.9.0
+```
+
+**That line is not decoration.** A local branch nobody fast-forwarded resolves silently to whatever it
+last pointed at, and the first real use of this script compared `master` against `0.6.0` where `master`
+*was* `0.6.0` — reporting no change, confidently, having compared nothing. Two revisions resolving to the
+same commit is now refused before either run starts, along with a revision that does not exist, because
+finding either out after the first run costs an hour on a real library.
+
+Exit status is **0** when nothing that matters changed, **1** when something did, and **2** whenever it
+could not compare at all — a missing input, a bad revision, two revisions that are the same commit, or a
+run that aborted. Anything that produced no comparison exits 2 rather than reporting no change.
 
 ## Environment
 

--- a/test/bin/compare_versions.pl
+++ b/test/bin/compare_versions.pl
@@ -39,17 +39,41 @@ usage(0) if $help;
 usage(1) unless defined $bam and defined $snps;
 $bam  = abs_path($bam);
 $snps = abs_path($snps);
-die "No such BAM: $bam\n"       unless -e $bam;
-die "No such SNP file: $snps\n" unless -e $snps;
+bail("No such BAM: $bam")       unless -e $bam;
+bail("No such SNP file: $snps") unless -e $snps;
 
 my $repo = abs_path(File::Spec->catdir(dirname(__FILE__), '..', '..'));
 
 ### SNPsplit tests --samtools_path with -e, so a bare program name is rejected. Resolved here rather
 ### than passed through, so the same binary is used for both runs and for the comparison.
 $samtools = defined $samtools ? abs_path($samtools) : which('samtools');
-die "samtools not found; pass --samtools PATH\n" unless defined $samtools && -x $samtools;
+bail("samtools not found; pass --samtools PATH") unless defined $samtools && -x $samtools;
 $outdir = defined $outdir ? abs_path($outdir)
                           : File::Spec->catdir(($ENV{TMPDIR} || '/tmp'), "snpsplit_compare_$$");
+
+### Both revisions are resolved before anything runs. Discovering a typo, or that the two sides are the
+### same commit, after the first run has finished costs an hour on a real library - which is the only
+### kind of input this script is for.
+my @sha;
+for my $rev ($old, $new) {
+    my $sha = `git -C '$repo' rev-parse --verify --quiet '$rev^{commit}' 2>/dev/null`;
+    chomp $sha;
+    unless (length $sha) {
+	warn "'$rev' is not a revision in $repo.\n";
+	my @tags = `git -C '$repo' tag`;
+	chomp @tags;
+	warn "Tags available: @{[ join ' ', @tags ]}\n";
+	bail("Pass a tag, branch or commit that exists.");
+    }
+    push @sha, substr($sha,0,7);
+}
+
+### A local branch nobody updated resolves silently to whatever it last pointed at, and comparing it
+### against itself produces a confident "no change" that says nothing about either version.
+if ($sha[0] eq $sha[1]) {
+    warn "'$old' and '$new' are both $sha[0]. There is nothing to compare.\n";
+    bail("A local branch is probably stale - try 'origin/master', or fetch and fast-forward it.");
+}
 
 warn "Comparing '$old' against '$new'\n";
 warn "BAM:       $bam\n";
@@ -57,6 +81,7 @@ warn "SNP file:  $snps\n";
 warn "Workspace: $outdir\n\n";
 
 my %ran;
+my @resolved;
 for my $rev ($old, $new) {
     my $label = label_for($rev);
     my $dir   = File::Spec->catdir($outdir, $label);
@@ -69,6 +94,16 @@ for my $rev ($old, $new) {
         run("git -C '$repo' show '$rev:$script' > '$dst'");
         chmod 0755, $dst;
     }
+
+    ### What the revision actually resolved to, and what it calls itself. A local branch that was never
+    ### updated resolves silently to whatever it last pointed at: 'master' compared against 'master'
+    ### once produced a confident "no change" because both sides were the same stale commit.
+    my $sha = `git -C '$repo' rev-parse --short '$rev^{commit}'`;
+    chomp $sha;
+    my ($stamp) = map { /_version = '([^']+)'/ ? $1 : () }
+                  split /^/, slurp(File::Spec->catfile($dir, 'SNPsplit'));
+    warn "[$label] $rev is $sha, and reports version @{[ $stamp || '?' ]}\n";
+    push @resolved, { label => $label, rev => $rev, sha => $sha, stamp => $stamp };
 
     my $work = File::Spec->catdir($dir, 'run');
     make_path($work);
@@ -154,6 +189,14 @@ exit $verdict;
 
 ###############################################################################
 
+### Everything that means "could not compare" leaves the same status, so a caller can tell that apart
+### from "compared, and something changed".
+sub bail {
+    my ($msg) = @_;
+    warn "$msg\n";
+    exit 2;
+}
+
 sub label_for { my $r = shift; $r =~ s/[^A-Za-z0-9._-]/_/g; return $r }
 
 sub listing {
@@ -177,6 +220,15 @@ sub same {
 sub run {
     my ($cmd) = @_;
     system($cmd) == 0 or die "failed: $cmd\n";
+}
+
+sub slurp {
+    my ($file) = @_;
+    open my $fh, '<', $file or return '';
+    local $/;
+    my $c = <$fh>;
+    close $fh;
+    return defined $c ? $c : '';
 }
 
 sub which {


### PR DESCRIPTION
Test-only. Fixes a false negative in `compare_versions.pl` found by using it: its first real run reported "no change in alignment records" for 0.6.0 against `master`, having compared **0.6.0 against 0.6.0**. The local `master` branch had never been fast-forwarded, so `git show master:tag2sort` returned a three-release-old file, and the verdict said nothing about either version.

Each side now prints the commit it resolved to and the version it stamps:

```
[0.6.0]         0.6.0         is 6e49c58, and reports version 0.6.0
[origin_master] origin/master is 499292f, and reports version 0.9.0
```

Two revisions resolving to the same commit, and a revision that does not exist, are both refused before either run starts — finding either out afterwards costs an hour on a real library, which is the only kind of input this script is for.

<details>
<summary>Detail (AI-assisted)</summary>

**The resolved-version line is what caught the next stale ref**, moments later: `origin/master` was still showing 0.8.0 because the last fetch predated the 0.9.0 release merge. Without that line printed, that run would have looked like a valid 0.9.0 comparison too.

**Every "could not compare" path now exits 2**, so a caller can tell it apart from "compared, and something changed". Verified on all five: missing input, bad revision, identical revisions, no change, changed.

**Confirmed working end to end** against the real released 0.9.0. `se_basic` gives exit 0 with everything identical; `hic_no_g1` gives exit 1 with all seven BAMs identical and three reports differing by exactly #90's fix:

```
- Read pairs were specific for genome 1 (G1/G1):		 (0.00%)
+ Read pairs were specific for genome 1 (G1/G1):		0 (0.00%)
```

That is the useful shape of result: three releases of fixes changed reporting and error handling, and left read assignment byte-identical.

</details>
