### PR TITLE
Document the output directory option under its registered name

### DIFF
--- a/SNPsplit
+++ b/SNPsplit
@@ -1917,7 +1917,7 @@ sub print_helpfile{
 
     --paired               Paired-end mode. (Default: AUTO-DETECT).
 
-    -o/--outdir <dir>      Write all output files into this directory. By default the output files will be written into
+    -o/--output_dir <dir>  Write all output files into this directory. By default the output files will be written into
                            the same folder as the input file(s). If the specified folder does not exist, SNPsplit will attempt
                            to create it first. The path to the output folder can be either relative or absolute.
 

--- a/docs/options/SNPsplit_options.md
+++ b/docs/options/SNPsplit_options.md
@@ -35,7 +35,7 @@ Manually sets data to single-end. Skips AUTO-DETECT
 
 Paired-end mode. (Default: AUTO-DETECT)
 
-- `-o/--outdir <dir>`
+- `-o/--output_dir <dir>`
 
 Write all output files into this directory. By default the output files will be written into the same folder as the input file(s). If the specified folder does not exist, SNPsplit will attempt to create it first. The path to the output folder can be either relative or absolute.
 

--- a/tag2sort
+++ b/tag2sort
@@ -1072,7 +1072,7 @@ be assigned to a specific allele, and they are one of the following:
 
 --paired               Paired-end mode. (Default: OFF).
 
--o/--outdir <dir>      Write all output files into this directory. By default the output files will be written into
+-o/--output_dir <dir>  Write all output files into this directory. By default the output files will be written into
                        the same folder as the input file(s).
 
 --singletons           If the allele-tagged paired-end file also contains singleton alignments (which is the

--- a/test/README.md
+++ b/test/README.md
@@ -304,7 +304,7 @@ always writes strand `1`, so a `-1` can only arrive through a hand-written `--sk
 
 ## Proving the fixtures assert anything
 
-`29 passed` alone only proves the fixtures are self-consistent. Two checks establish more, both run by
+`31 passed` alone only proves the fixtures are self-consistent. Two checks establish more, both run by
 hand:
 
 ```sh


### PR DESCRIPTION
`--help` and `docs/options/SNPsplit_options.md` promised `-o/--outdir <dir>`, but the registered option is `output_dir` and Getopt::Long matches abbreviations by prefix, so `--outdir` was rejected outright while `-o` worked. Documentation only — no option was added, removed or renamed, and no behaviour changes. Second commit corrects a stale fixture count in `test/README.md`.