### PR TITLE
docs(rust): design for a Rust rewrite (#89)

### DIFF
--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -1,0 +1,239 @@
+# SNPsplit Rust rewrite: design
+
+Status: proposal. Nothing in this document is merged behaviour yet.
+
+This is the design for porting SNPsplit from Perl to Rust, raised in
+[#89](https://github.com/FelixKrueger/SNPsplit/issues/89). It exists so the shape of the
+work is agreed before any of it lands, and so a reviewer can tell, at any point in the
+stack, what is ported and what is not.
+
+## Scope
+
+All three tools:
+
+| Tool | Perl lines | Fixture coverage today |
+|---|---|---|
+| `SNPsplit` | 1996 | `test/run_tests.pl`, 26 fixtures |
+| `tag2sort` | 1311 | same suite (driven by `SNPsplit`) |
+| `SNPsplit_genome_preparation` | 1788 | `test/run_genome_tests.pl`, 13 fixtures |
+
+Issue #89 records a narrower option (`SNPsplit` + `tag2sort` as one binary, genome
+preparation left in Perl) on the grounds that genome preparation is single-use and gains
+nothing from being fast. That reasoning is about *performance*, and performance is not the
+motivation here. The motivation is a single binary with no Perl and no samtools at runtime,
+and a Perl genome preparation step would keep both dependencies alive for the one part of
+the workflow that a user runs first. So: all three, one binary.
+
+## What "done" means
+
+Byte-identical output to Perl SNPsplit v0.9.0, proven by the existing fixture suites rather
+than asserted.
+
+Both runners already accept `--impl PATH`, and were written with this in mind ("Point
+`--impl` at any implementation (Perl today, Rust later) to diff it against the same expected
+output", `test/run_tests.pl:18`). They stage the implementation into a scratch directory,
+run every fixture, normalise every file the run produces, and diff against committed
+`expected/` trees. That is the acceptance gate for this port, unchanged.
+
+Two details of the existing normalisation matter to the design:
+
+- `test/run_tests.pl:384` rewrites `^(Samtools path:\s*)\S+` to `<samtools>`. The Rust
+  implementation can print any single non-whitespace token there and still match.
+- `test/run_genome_tests.pl:397` rewrites `<impl_name> line <digits>` to
+  `<impl_name> line <n>`, masking the line number but keeping the rest of the Perl `die`
+  suffix. A Rust error message has no such suffix at all, so every fixture whose `expected/`
+  carries one has to be reconciled (see PR 3).
+
+## Architecture
+
+### Layout
+
+```
+rust/
+  Cargo.toml          workspace
+  Cargo.lock
+  VERSION             suite version, single source of truth
+  justfile            just impl, just test, just fixtures
+  DESIGN.md           this file
+  README.md           status journal: which module is ported, at what fidelity
+  snpsplit/
+    Cargo.toml
+    src/
+      main.rs         multicall dispatch
+      lib.rs
+      io/             noodles wrappers: SAM/BAM read, BAM write, name sort
+      tag/            the SNPsplit tagging tool
+      sort/           the tag2sort tool
+      genome_prep/    the SNPsplit_genome_preparation tool
+      report/         .txt report and .yaml report writers, shared
+```
+
+One crate with modules, not a crate per tool. The three tools share the SNP annotation
+reader, the report writers and the BAM layer, and a workspace of three thin binary crates
+around one fat library crate buys nothing but manifest churn. (Bismark's Rust suite started
+as a crate per tool and converged on exactly this single-crate multicall shape.)
+
+### Binary naming
+
+One binary, `snpsplit`, dispatching on `argv[0]` and on a subcommand:
+
+```
+snpsplit tag ...     == SNPsplit ...
+snpsplit sort ...    == tag2sort ...
+snpsplit prepare ... == SNPsplit_genome_preparation ...
+```
+
+The three classic names are installed as symlinks to the one binary, so existing pipelines
+and the fixture runners (which invoke `SNPsplit` and require `tag2sort` to sit beside it,
+`test/run_tests.pl:42`) are drop-in.
+
+During the port, `just impl` builds and links them into `rust/target/impl/`, so the gate is:
+
+```
+test/run_tests.pl --impl rust/target/impl/SNPsplit
+test/run_genome_tests.pl --impl rust/target/impl/SNPsplit_genome_preparation
+```
+
+Whether the released binaries carry the classic names outright or a suffix during a beta
+(as Bismark's `_rs` binaries did, so they could share a `PATH` with the Perl scripts) is a
+packaging decision, deferred to PR 19.
+
+### BAM I/O
+
+Pure Rust via [noodles](https://github.com/zaeleus/noodles). No samtools subprocess, no
+htslib build dependency.
+
+This is the single largest behavioural change in the port, and it has consequences that are
+not cosmetic:
+
+1. **`--samtools_path` loses its job.** It stays accepted, so no existing command line
+   breaks, but it is a no-op that prints a notice. The `Samtools path:` report line stays
+   (masked by the runner anyway) so report layout is unchanged.
+2. **Name sorting becomes ours.** `sort_by_name_paired_end` (`SNPsplit:1394`) shells out to
+   `samtools sort -n`. In-memory sorting is not an option for real inputs, so PR 2 has to
+   write an external merge sort with disk spill. This is the highest-risk item in the stack.
+   Fallback, if it proves unreasonable: keep `samtools sort -n` as a subprocess for that one
+   path, and record the exception in `rust/README.md` rather than hiding it.
+3. **Four fixtures encode the samtools architecture** and cannot pass unmodified:
+   `samtools_path`, `samtools_path_spaced` (both assert a poison shim is never reached),
+   `bam_write_fails` and `sam2bam_fails` (both simulate a failing samtools wrapper). PR 18
+   re-expresses each in terms the port can honour: the two path fixtures assert the no-op
+   notice, and the two failure fixtures induce a real write failure (read-only output
+   directory) instead of a fake samtools.
+
+Every other output difference is a bug in the port, not a consequence of the design.
+
+## The fidelity gate
+
+A port that lands in twenty pieces spends most of its life partially complete, and the
+honest question at every one of those points is "which fixtures pass?". Encoding the answer
+in CI, rather than in a PR description, is what keeps the stack reviewable.
+
+`test/rust_fixtures.txt` lists the fixtures the Rust implementation is expected to pass. CI
+gains two jobs that run both suites against `rust/target/impl/` and fail on either side of
+the line:
+
+- a fixture on the list that fails, which is a regression;
+- a fixture off the list that passes, which means the list is stale and someone forgot to
+  claim their own work.
+
+Failing in the second direction is the point. A plain skip list rots silently; this one
+cannot. Each porting PR adds its fixtures to the list in the same commit that makes them
+pass, so the diff always shows what was actually bought.
+
+The Perl jobs stay exactly as they are and stay green throughout. The Perl implementation is
+not touched by this stack.
+
+## The stack
+
+All PRs target the `rust` integration branch. Feature branches are `rs-*` rather than
+`rust/*`, because git cannot hold both a `rust` ref and a `rust/...` ref at once.
+
+The intent is that `rust` is merged to `master` once, as a single reviewed unit, with the
+individual PRs serving as its readable history.
+
+### Phase 0: foundation
+
+| PR | Branch | Contents |
+|---|---|---|
+| 1 | `rs-scaffold` | Cargo workspace, `snpsplit` crate skeleton, multicall dispatch, `--version` and `--help` for all three names, `rust/README.md` journal, `just impl`, CI job for fmt/clippy/test |
+| 2 | `rs-io` | noodles SAM/BAM reader and BAM writer, header and `@PG` handling, external name sort with disk spill, unit tests |
+| 3 | `rs-harness` | `test/rust_fixtures.txt` plus the two CI jobs; reconcile the Perl `die`-shape masking in both runners. Perl suites stay green |
+
+### Phase 1: genome preparation (13 fixtures, no BAM)
+
+Ported first because it touches no alignments and has its own runner, so it proves the whole
+chain (cargo, CI, allowlist, report fidelity) without waiting on `rs-io`.
+
+| PR | Branch | Contents |
+|---|---|---|
+| 4 | `rs-gp-cli` | CLI surface, argument validation, `detect_chroms`, `detect_strains`; fixture `list_strains` |
+| 5 | `rs-gp-vcf` | VCF filtering, high-confidence SNP selection, `SNPs_<strain>/chr*.txt`, gzipped `all_SNPs_*`, skipped-position reporting |
+| 6 | `rs-gp-genome` | genome into memory, N-masking and full-sequence genomes; `nmask_basic`, `full_sequence`, `multi_chrom`, `multifasta`, `fasta_extension` |
+| 7 | `rs-gp-dual` | dual hybrid path, `genotypes`, and the five failure fixtures (`chrom_name_mismatch`, `duplicate_chrom_name`, `empty_chromosome`, `empty_genome_folder`, `missing_genome`). Genome preparation suite complete at 13/13 |
+
+### Phase 2: tag2sort
+
+Ported before the tagger, because the Perl `SNPsplit` can drive a Rust `tag2sort`: the
+runner stages both from `dirname(--impl)`, so a mixed directory is a valid gate.
+
+| PR | Branch | Contents |
+|---|---|---|
+| 8 | `rs-sort-cli` | CLI, report and YAML writers |
+| 9 | `rs-sort-se` | `process_single_end`; `se_basic`, `se_skipped` |
+| 10 | `rs-sort-pe` | `princess_paired_end` and singleton handling; `pe_basic`, `pe_singletons`, `pe_namesort` |
+| 11 | `rs-sort-hic` | `process_HiC_paired_end`; `hic`, `hic_no_g1` |
+
+### Phase 3: SNPsplit tagging
+
+| PR | Branch | Contents |
+|---|---|---|
+| 12 | `rs-tag-cli` | CLI, `read_snps` for both annotation formats including the per-chromosome format from #107, report and YAML |
+| 13 | `rs-tag-se` | `process_masked_BAM_file` single-end, `score_snp_position`, `determine_N_position`, CIGAR handling; `cigar_complex`, `cigar_eqx`, `n_deletions` |
+| 14 | `rs-tag-pe` | paired-end, the `--no_sorting` path; `multi_input`, `output_dir` |
+| 15 | `rs-tag-hic` | Hi-C tagging |
+| 16 | `rs-tag-bs` | `score_bisulfite_SNPs`, `check_for_bs` autodetection; `bisulfite_se`, `bismark_autodetect`, `bismark_autodetect_se` |
+| 17 | `rs-tag-handoff` | in-process handoff from tagging to sorting, `--skip_tag2sort`, `sam_input`, `sam_output` |
+
+### Phase 4: closing
+
+| PR | Branch | Contents |
+|---|---|---|
+| 18 | `rs-fixtures-samtools` | re-express the four samtools-architecture fixtures. Alignment suite complete at 26/26 |
+| 19 | `rs-packaging` | cargo metadata, release workflow, prebuilt binaries, container image |
+| 20 | `rs-docs` | documentation site pages, README, CHANGELOG, and the body of the umbrella PR |
+
+## Testing
+
+Three layers, in increasing cost:
+
+1. **Unit tests** inside each module, for the pieces with no I/O: CIGAR walking, SNP
+   scoring, the bisulfite call, VCF field parsing. These are where a port actually goes
+   wrong, and they are cheap enough to write per function.
+2. **The two fixture suites** under `--impl`, gated by `test/rust_fixtures.txt`, run on every
+   PR. This is the byte-identity contract.
+3. **`test/bin/compare_versions.pl`**, the real-data harness, run by hand before the umbrella
+   PR against a full mouse dataset. Fixtures are small by construction; a full run is the
+   only thing that exercises memory behaviour and the external sort at scale.
+
+## Error handling
+
+Perl `die` messages are user-facing contract here: fixtures diff them. The port reproduces
+the message text exactly, minus the ` at <script> line <n>.` suffix that Perl appends and
+the runner masks. Exit statuses are diffed too (`expected/exit_status`), so they are
+reproduced rather than approximated.
+
+Internally, `anyhow` at the binary edge and typed errors inside modules. No `unwrap` on
+anything derived from input: a malformed VCF line or a truncated BAM has to produce the
+Perl message, not a panic.
+
+## Deliberately out of scope
+
+- Behaviour changes, new options, and output-format improvements. This is a port. Anything
+  that would change output belongs in its own issue against the Perl version first, so the
+  fixture suite records the change once and both implementations agree on it.
+- Multithreading. The Perl tools are single-threaded, output order is part of the contract,
+  and #89 is explicit that performance is not the motivation. Parallelism can come later,
+  behind a flag, once byte-identity is established and can prove it did not break anything.
+- Retiring the Perl scripts. That is Felix's call, after this lands, and it is a one-line
+  change to make.

--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -201,7 +201,59 @@ runner stages both from `dirname(--impl)`, so a mixed directory is a valid gate.
 |---|---|---|
 | 18 | `rs-fixtures-samtools` | re-express the four samtools-architecture fixtures. Alignment suite complete at 26/26 |
 | 19 | `rs-packaging` | cargo metadata, release workflow, prebuilt binaries, container image |
-| 20 | `rs-docs` | documentation site pages, README, CHANGELOG, and the body of the umbrella PR |
+| 20 | `rs-gp-download` | `--download`: fetch the MGP VCF and the reference genome. The one deliberate behaviour addition, isolated on purpose |
+| 21 | `rs-docs` | documentation site pages, README, CHANGELOG, and the body of the umbrella PR |
+
+## The one deliberate addition: fetching the references
+
+Everything else in this stack is a port. This is not, and it is called out separately so a
+reviewer can hold it to a different standard.
+
+Today, running `SNPsplit_genome_preparation` means first finding and downloading two things
+by hand: the Mouse Genomes Project SNP VCF (currently `mgp_REL2021_snps.vcf.gz`, v8, from
+the EBI mirror) and a reference genome folder of per-chromosome FASTA files. Both URLs live
+in comments in the Perl source (`SNPsplit_genome_preparation:27`) and in the documentation,
+which is where users go looking for them. A tool that already knows which build it wants
+can fetch them.
+
+### Surface
+
+```
+--download                 fetch whatever of the two inputs is missing
+--download_dir PATH        where they land. Default: ./SNPsplit_references/
+--ensembl_release N        reference genome release to fetch. Default: pinned, documented
+```
+
+`--genome_build` (default GRCm39) and `--v7_VCF` already exist and are honoured: v8 comes
+from the EBI `REL-2112-v8-SNPs_Indels` path, v7 from the Sanger `REL-2004-v7-SNPs_Indels`
+path, and the genome is Ensembl's per-chromosome FASTA set for the requested build, which is
+already the folder-of-chromosomes layout `--reference_genome` expects.
+
+### Rules
+
+- **Opt-in, and nothing else touches the network.** Without `--download` the binary makes no
+  outbound connection at all. With it, only the two known hosts are contacted.
+- **Never overwrites what the user passed.** If `--vcf_file` or `--reference_genome` names an
+  existing path, that path wins and is not re-fetched.
+- **Resumable.** A partial file is continued with an HTTP range request rather than
+  restarted, because the VCF is large enough that losing a download to a dropped connection
+  is a real cost.
+- **Verified.** Ensembl publishes a `CHECKSUMS` file per directory, which is checked. The MGP
+  VCF has no published checksum, so it is verified by decompressing the whole gzip stream and
+  requiring a valid VCF header, which catches the truncation and error-page cases that
+  actually happen. Whatever is fetched, its URL, size and SHA-256 are recorded in
+  `<download_dir>/manifest.txt`, so a later run can say whether the remote file has changed
+  rather than silently using a different input.
+- **Fails loudly.** A 404, a checksum mismatch or a truncated stream aborts with the URL in
+  the message. No falling back to a partial file.
+
+### Testing
+
+CI does not contact EBI or Ensembl. The fixtures run against a local HTTP server serving
+canned responses: `download_fresh`, `download_resume` (a truncated file plus a range
+request), `download_checksum_mismatch`, and `download_no_flag` (asserting no socket is
+opened without `--download`). Live URLs are exercised by hand before release, not on every
+push.
 
 ## Testing
 
@@ -229,9 +281,10 @@ Perl message, not a panic.
 
 ## Deliberately out of scope
 
-- Behaviour changes, new options, and output-format improvements. This is a port. Anything
-  that would change output belongs in its own issue against the Perl version first, so the
-  fixture suite records the change once and both implementations agree on it.
+- Behaviour changes, new options, and output-format improvements, with the single exception
+  of `--download` below. This is a port. Anything that would change output belongs in its
+  own issue against the Perl version first, so the fixture suite records the change once and
+  both implementations agree on it.
 - Multithreading. The Perl tools are single-threaded, output order is part of the contract,
   and #89 is explicit that performance is not the motivation. Parallelism can come later,
   behind a flag, once byte-identity is established and can prove it did not break anything.

--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -53,7 +53,7 @@ rust/
   Cargo.toml          workspace
   Cargo.lock
   VERSION             suite version, single source of truth
-  justfile            just impl, just test, just fixtures
+  build-impl.sh       builds the binary and lays out the three classic names
   DESIGN.md           this file
   README.md           status journal: which module is ported, at what fidelity
   snpsplit/
@@ -87,7 +87,9 @@ The three classic names are installed as symlinks to the one binary, so existing
 and the fixture runners (which invoke `SNPsplit` and require `tag2sort` to sit beside it,
 `test/run_tests.pl:42`) are drop-in.
 
-During the port, `just impl` builds and links them into `rust/target/impl/`, so the gate is:
+During the port, `rust/build-impl.sh` builds and links them into `rust/target/impl/`, so the
+gate is (a shell script rather than a `justfile`, so running the gate needs cargo and
+nothing else):
 
 ```
 test/run_tests.pl --impl rust/target/impl/SNPsplit
@@ -123,6 +125,25 @@ not cosmetic:
 
 Every other output difference is a bug in the port, not a consequence of the design.
 
+### Why not `bismark-io`
+
+`bismark-io` 1.0.0 is on crates.io, GPL-3.0, from this author, described as "Bismark-aware
+BAM/SAM/CRAM I/O on top of noodles". Reusing it would make the two Rust tools share a layer,
+which is worth something. It is not used here for two reasons: it carries bisulfite-aware
+semantics that SNPsplit does not want in its BAM layer, and it puts a cross-repo dependency,
+whose release cadence this repo does not control, underneath a byte-identity gate. What
+SNPsplit needs (record read, record write, name sort) is a small subset that noodles covers
+directly. Worth revisiting if the two suites ever want a common release train.
+
+### The version flag is not harmonised
+
+`SNPsplit --versions` and `SNPsplit_genome_preparation --versions` are plural,
+`tag2sort --version` is singular, and `tag2sort --versions` is rejected with
+`Unknown option: versions`, `Please respecify command line options`, and exit status 255.
+That is observable from any shell script, so the port reproduces it rather than tidying it.
+The three banners are captured from the Perl and compiled in verbatim rather than retyped,
+so they cannot drift.
+
 ## The fidelity gate
 
 A port that lands in twenty pieces spends most of its life partially complete, and the
@@ -156,7 +177,7 @@ individual PRs serving as its readable history.
 
 | PR | Branch | Contents |
 |---|---|---|
-| 1 | `rs-scaffold` | Cargo workspace, `snpsplit` crate skeleton, multicall dispatch, `--version` and `--help` for all three names, `rust/README.md` journal, `just impl`, CI job for fmt/clippy/test |
+| 1 | `rs-scaffold` | Cargo workspace, `snpsplit` crate skeleton, multicall dispatch, byte-exact version banners for all three names, `rust/README.md` journal, `build-impl.sh`, CI job for fmt/clippy/test |
 | 2 | `rs-io` | noodles SAM/BAM reader and BAM writer, header and `@PG` handling, external name sort with disk spill, unit tests |
 | 3 | `rs-harness` | `test/rust_fixtures.txt` plus the two CI jobs; reconcile the Perl `die`-shape masking in both runners. Perl suites stay green |
 

--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -15,7 +15,7 @@ All three tools:
 |---|---|---|
 | `SNPsplit` | 1996 | `test/run_tests.pl`, 26 fixtures |
 | `tag2sort` | 1311 | same suite (driven by `SNPsplit`) |
-| `SNPsplit_genome_preparation` | 1788 | `test/run_genome_tests.pl`, 13 fixtures |
+| `SNPsplit_genome_preparation` | 1788 | `test/run_genome_tests.pl`, 31 fixtures |
 
 Issue #89 records a narrower option (`SNPsplit` + `tag2sort` as one binary, genome
 preparation left in Perl) on the grounds that genome preparation is single-use and gains
@@ -181,7 +181,7 @@ individual PRs serving as its readable history.
 | 2 | `rs-io` | noodles SAM/BAM reader and BAM writer, header and `@PG` handling, external name sort with disk spill, unit tests |
 | 3 | `rs-harness` | `test/rust_fixtures.txt` plus the two CI jobs; reconcile the Perl `die`-shape masking in both runners. Perl suites stay green |
 
-### Phase 1: genome preparation (13 fixtures, no BAM)
+### Phase 1: genome preparation (31 fixtures, no BAM)
 
 Ported first because it touches no alignments and has its own runner, so it proves the whole
 chain (cargo, CI, allowlist, report fidelity) without waiting on `rs-io`.
@@ -191,7 +191,7 @@ chain (cargo, CI, allowlist, report fidelity) without waiting on `rs-io`.
 | 4 | `rs-gp-cli` | CLI surface, argument validation, `detect_chroms`, `detect_strains`; fixture `list_strains` |
 | 5 | `rs-gp-vcf` | VCF filtering, high-confidence SNP selection, `SNPs_<strain>/chr*.txt`, gzipped `all_SNPs_*`, skipped-position reporting |
 | 6 | `rs-gp-genome` | genome into memory, N-masking and full-sequence genomes; `nmask_basic`, `full_sequence`, `multi_chrom`, `multifasta`, `fasta_extension` |
-| 7 | `rs-gp-dual` | dual hybrid path, `genotypes`, and the five failure fixtures (`chrom_name_mismatch`, `duplicate_chrom_name`, `empty_chromosome`, `empty_genome_folder`, `missing_genome`). Genome preparation suite complete at 13/13 |
+| 7 | `rs-gp-dual` | dual hybrid path, `genotypes`, `skip_filtering`, `same_strain`, and the failure fixtures (`chrom_name_mismatch`, `duplicate_chrom_name`, `empty_chromosome`, `empty_genome_folder`, `missing_genome`, `not_fasta`, `no_snp_folder`, `strain_not_in_vcf`, `undeclared_contig`, `vcf_missing`, `ref_mismatch`, `poison_gzip`, ...). Genome preparation suite complete at 31/31 |
 
 ### Phase 2: tag2sort
 

--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -180,6 +180,7 @@ individual PRs serving as its readable history.
 | 1 | `rs-scaffold` | Cargo workspace, `snpsplit` crate skeleton, multicall dispatch, byte-exact version banners for all three names, `rust/README.md` journal, `build-impl.sh`, CI job for fmt/clippy/test |
 | 2 | `rs-io` | noodles SAM/BAM reader and BAM writer, header and `@PG` handling, external name sort with disk spill, unit tests |
 | 3 | `rs-harness` | `test/rust_fixtures.txt` plus the two CI jobs; reconcile the Perl `die`-shape masking in both runners. Perl suites stay green |
+| 3b | `rs-io-mt` | multithreaded BGZF read and write, parallel run sorting, and the worker-count-invariance test that the later tools inherit |
 
 ### Phase 1: genome preparation (31 fixtures, no BAM)
 
@@ -221,6 +222,7 @@ runner stages both from `dirname(--impl)`, so a mixed directory is a valid gate.
 | PR | Branch | Contents |
 |---|---|---|
 | 18 | `rs-fixtures-samtools` | re-express the four samtools-architecture fixtures. Alignment suite complete at 26/26 |
+| 18b | `rs-parallel-gate` | run both suites at `--parallel 1` and `--parallel 4` in CI, and publish measured timings |
 | 19 | `rs-packaging` | cargo metadata, release workflow, prebuilt binaries, container image |
 | 20 | `rs-gp-download` | `--download`: fetch the MGP VCF and the reference genome. The one deliberate behaviour addition, isolated on purpose |
 | 21 | `rs-docs` | documentation site pages, README, CHANGELOG, and the body of the umbrella PR |
@@ -268,7 +270,62 @@ already the folder-of-chromosomes layout `--reference_genome` expects.
 - **Fails loudly.** A 404, a checksum mismatch or a truncated stream aborts with the URL in
   the message. No falling back to a partial file.
 
-### Testing
+### Parallelism
+
+The Perl tools are single-threaded. This port is not, and the reason it can afford not to be
+is the same reason the port is tractable at all: the fixture suites can prove that the
+output did not move.
+
+### The invariant
+
+**Output is byte-identical regardless of the worker count.** Not "deterministic per worker
+count", which is a much weaker claim and the one that is easy to accidentally ship.
+Everything below is arranged so that parallelism changes when work happens, never what is
+written or in what order.
+
+This is checkable, so it is checked: the CI gate runs both fixture suites twice, at
+`--parallel 1` and `--parallel 4`, and compares each against the same committed `expected/`
+trees. A parallel path that reorders output fails the same gate that a mis-ported CIGAR walk
+would.
+
+### The knob
+
+One flag, `--parallel N`, on all three tools. Default `1`, so an existing command line
+behaves exactly as it does today. `--parallel 0` means every available core.
+
+One knob rather than a knob per stage: the stages below are sequential with respect to each
+other, so a single number is enough to describe the whole run, and a single number is what a
+job scheduler can be told about.
+
+### Where the time actually goes, and what each part buys
+
+1. **BGZF encode and decode.** Compression is the largest single cost in any BAM-in,
+   BAM-out tool, and `noodles-bgzf` already ships `MultithreadedWriter` and
+   `MultithreadedReader`. Block boundaries make this order-preserving by construction. The
+   compressed bytes may differ from the single-threaded encoding; the decoded content does
+   not, and the fixtures compare `samtools view` output, not BGZF bytes.
+2. **Per-record work, with ordered writeback.** Tagging walks a CIGAR against the SNP table
+   for every read; sorting classifies every read or pair. Records are handed to workers in
+   fixed-size batches and results are written back in batch order through a bounded reorder
+   buffer, so the output stream is the serial stream. The batch size is fixed in the source,
+   not a flag, because it is not a user's decision and varying it would make the invariant
+   harder to state.
+3. **Per-chromosome work in the genome preparation.** Each chromosome is N-masked
+   independently and written to its own file, which is the cleanest parallelism in the whole
+   codebase: separate inputs, separate outputs, no ordering question. This is also the stage
+   #89 argues gains nothing from being fast, and it is right that a single-use step matters
+   less; it is parallelised because it is nearly free to do, not because it was the goal.
+4. **Run sorting inside the external name sort.** Each in-memory run is sorted independently
+   before it spills. The merge stays sequential, because it is the merge that fixes the
+   order.
+
+### What is deliberately not parallelised
+
+The merge phase of the name sort, and the writing of any single output file beyond its BGZF
+encoding. Both are the points where order is decided, and a faster wrong order is worse than
+a slower right one.
+
+## Testing
 
 CI does not contact EBI or Ensembl. The fixtures run against a local HTTP server serving
 canned responses: `download_fresh`, `download_resume` (a truncated file plus a range
@@ -306,8 +363,5 @@ Perl message, not a panic.
   of `--download` below. This is a port. Anything that would change output belongs in its
   own issue against the Perl version first, so the fixture suite records the change once and
   both implementations agree on it.
-- Multithreading. The Perl tools are single-threaded, output order is part of the contract,
-  and #89 is explicit that performance is not the motivation. Parallelism can come later,
-  behind a flag, once byte-identity is established and can prove it did not break anything.
 - Retiring the Perl scripts. That is Felix's call, after this lands, and it is a one-line
   change to make.

--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -108,9 +108,14 @@ htslib build dependency.
 This is the single largest behavioural change in the port, and it has consequences that are
 not cosmetic:
 
-1. **`--samtools_path` loses its job.** It stays accepted, so no existing command line
-   breaks, but it is a no-op that prints a notice. The `Samtools path:` report line stays
+1. **`--samtools_path` loses its job.** It stays accepted and still validated, so a wrong
+   path is still reported, but nothing runs through it. The `Samtools path:` report line stays
    (masked by the runner anyway) so report layout is unchanged.
+
+   An earlier draft said it would print a notice saying so. It cannot: `samtools_path` and
+   `samtools_path_spaced` pin an exact 91-line log, and an extra line breaks both. The choice
+   is between telling the user something true and keeping two fixtures, and the fixtures win,
+   because byte-identity is the whole gate. It is documented instead.
 2. **Name sorting becomes ours.** `sort_by_name_paired_end` (`SNPsplit:1394`) shells out to
    `samtools sort -n`. In-memory sorting is not an option for real inputs, so PR 2 has to
    write an external merge sort with disk spill. This is the highest-risk item in the stack.

--- a/rust/DESIGN.md
+++ b/rust/DESIGN.md
@@ -270,7 +270,23 @@ already the folder-of-chromosomes layout `--reference_genome` expects.
 - **Fails loudly.** A 404, a checksum mismatch or a truncated stream aborts with the URL in
   the message. No falling back to a partial file.
 
-### Parallelism
+### Testing
+
+CI does not contact EBI or Ensembl. What is worth testing is the transfer, and that is
+covered by integration tests against a one-file HTTP server on an ephemeral port: a fresh
+fetch, a partial file resumed with a range request rather than restarted, a 404 that fails
+loudly and names the URL, and a truncated archive that does not verify.
+
+These are Rust tests rather than fixtures, which corrects an earlier draft of this section. A
+fixture would have to start a server, and the fixture runners take an implementation and a
+set of arguments, not a service.
+
+The live endpoints are checked by hand, not on every push. The v8 VCF is 23,305,938,445
+bytes, which is the reason resuming is not optional. The local server speaks plain HTTP, so
+it proves nothing about TLS; a real fetch of the smallest Ensembl chromosome does, and
+`rust/snpsplit/examples/fetch_probe.rs` is that check.
+
+## Parallelism
 
 The Perl tools are single-threaded. This port is not, and the reason it can afford not to be
 is the same reason the port is tractable at all: the fixture suites can prove that the
@@ -283,15 +299,22 @@ count", which is a much weaker claim and the one that is easy to accidentally sh
 Everything below is arranged so that parallelism changes when work happens, never what is
 written or in what order.
 
-This is checkable, so it is checked: the CI gate runs both fixture suites twice, at
-`--parallel 1` and `--parallel 4`, and compares each against the same committed `expected/`
-trees. A parallel path that reorders output fails the same gate that a mis-ported CIGAR walk
-would.
+This is checkable, so it is checked: the CI gate runs both fixture suites twice, at one
+worker and at four, and compares each against the same committed `expected/` trees. A
+parallel path that reorders output fails the same gate that a mis-ported CIGAR walk would.
+
+The worker count reaches the tools through `SNPSPLIT_PARALLEL`, which is the default when
+`--parallel` is absent. The fixture runners take an implementation and a set of arguments and
+have no way to pass an extra flag, so an environment default is what makes the same fixtures
+runnable at a second worker count without changing them. It earns its place beyond the tests
+too: a container or a scheduler can hand every tool in a pipeline the same budget without
+rewriting command lines.
 
 ### The knob
 
 One flag, `--parallel N`, on all three tools. Default `1`, so an existing command line
-behaves exactly as it does today. `--parallel 0` means every available core.
+behaves exactly as it does today. `--parallel 0` means every available core, and
+`SNPSPLIT_PARALLEL` sets the default when the flag is absent.
 
 One knob rather than a knob per stage: the stages below are sequential with respect to each
 other, so a single number is enough to describe the whole run, and a single number is what a
@@ -305,16 +328,22 @@ job scheduler can be told about.
    compressed bytes may differ from the single-threaded encoding; the decoded content does
    not, and the fixtures compare `samtools view` output, not BGZF bytes.
 2. **Per-record work, with ordered writeback.** Tagging walks a CIGAR against the SNP table
-   for every read; sorting classifies every read or pair. Records are handed to workers in
-   fixed-size batches and results are written back in batch order through a bounded reorder
-   buffer, so the output stream is the serial stream. The batch size is fixed in the source,
-   not a flag, because it is not a user's decision and varying it would make the invariant
-   harder to state.
+   for every read. Records are scored in fixed-size batches and written back in read order,
+   so the output stream is the serial stream. The batch size is fixed in the source, not a
+   flag, because it is not a user's decision and varying it would make the invariant harder
+   to state. Measured, this is worth about 1.4x and no more: the walk is real work but small
+   next to reading and writing the alignments.
+
+   The sorting step is deliberately excluded. Its per-record work is a tag lookup and a copy,
+   so the cost is I/O, which the BGZF workers already cover; parallelising it would be
+   theatre.
 3. **Per-chromosome work in the genome preparation.** Each chromosome is N-masked
-   independently and written to its own file, which is the cleanest parallelism in the whole
-   codebase: separate inputs, separate outputs, no ordering question. This is also the stage
-   #89 argues gains nothing from being fast, and it is right that a single-use step matters
-   less; it is parallelised because it is nearly free to do, not because it was the goal.
+   independently and written to its own file. That looks like the cleanest parallelism in the
+   codebase and is not quite: a serial run prints its logs in genome order and stops writing
+   as soon as one chromosome aborts. So each chromosome buffers everything it would print and
+   everything it would write, and the caller replays that in genome order, with an abort
+   travelling alongside its log rather than being returned. Two fixtures caught the naive
+   version.
 4. **Run sorting inside the external name sort.** Each in-memory run is sorted independently
    before it spills. The merge stays sequential, because it is the merge that fixes the
    order.
@@ -324,14 +353,6 @@ job scheduler can be told about.
 The merge phase of the name sort, and the writing of any single output file beyond its BGZF
 encoding. Both are the points where order is decided, and a faster wrong order is worse than
 a slower right one.
-
-## Testing
-
-CI does not contact EBI or Ensembl. The fixtures run against a local HTTP server serving
-canned responses: `download_fresh`, `download_resume` (a truncated file plus a range
-request), `download_checksum_mismatch`, and `download_no_flag` (asserting no socket is
-opened without `--download`). Live URLs are exercised by hand before release, not on every
-push.
 
 ## Testing
 


### PR DESCRIPTION
Following up on your comment in #89. This is the design only, no code, so the shape can be
argued with before any of it is written.

**Please do not merge this into `dev`.** It is the first of a stack. If the approach is
worth pursuing, the thing that would help most is a `rust` integration branch in this repo:
I would retarget this and everything after it onto it, and you would merge `rust` into
`master` once, as a single reviewed unit, exactly as the Bismark rewrite used
`rust/iron-chancellor`. Right now I can only aim at `dev`, which is the shape you said you
did not want to rush into.

## What it proposes

- **All three tools** (`SNPsplit`, `tag2sort`, `SNPsplit_genome_preparation`) as one
  multicall binary with `argv[0]` aliases, so pipelines are drop-in.
- **Pure-Rust BAM I/O via noodles.** No samtools at runtime, no htslib build dependency.
- **Byte-identity to Perl v0.9.0 as the acceptance gate**, using the `--impl` support that
  `test/run_tests.pl` and `test/run_genome_tests.pl` already carry. That harness is why this
  is worth attempting at all: 26 alignment fixtures and 13 genome fixtures, normalised and
  diffed, is a real gate rather than a claim.

## On scope

You suggested in #89 that a partial rewrite (tagger and sorter, genome preparation left in
Perl) would be the sensible cut, since genome preparation is single-use and gains nothing
from being fast. That is right about performance, but performance is not what this is for.
The point is a runtime with no Perl and no samtools, and a Perl genome preparation step
keeps both alive for the first thing a user runs. So the design covers all three. If you
would rather hold to the narrower cut, say so and the genome preparation PRs drop out
without disturbing the rest.

## How partial states stay honest

A twenty-PR port spends most of its life incomplete, so "which fixtures pass?" is answered
by CI, not by a PR description. `test/rust_fixtures.txt` lists the fixtures the Rust build is
expected to pass, and the gate fails in both directions: a listed fixture that fails is a
regression, and an unlisted fixture that passes means the list is stale. A plain skip list
would rot silently.

## Three things the noodles decision changes, recorded up front

1. `--samtools_path` stays accepted but becomes a no-op that prints a notice.
2. `sort_by_name_paired_end` delegates to `samtools sort -n`. In pure Rust that becomes an
   external merge sort, written here, and samtools' comparator is not byte-wise: digit runs
   compare numerically, so `read2` precedes `read10`. This is the highest-risk item.
3. `samtools_path`, `samtools_path_spaced`, `bam_write_fails` and `sam2bam_fails` encode the
   samtools architecture and cannot pass unmodified. They get re-expressed near the end.

No urgency, and this is not a request for your holiday. Refs #89.